### PR TITLE
fix: Corrige o content-type para não dar erro de requisição

### DIFF
--- a/src/stores/money.js
+++ b/src/stores/money.js
@@ -2,6 +2,11 @@ import Vapi from 'vuex-rest-api'
 import { baseUrls } from '@/configs'
 import { http } from '@/utils'
 
+http.interceptors.request.use(config => {
+  config.headers['Content-Type'] = 'application/xml';
+  return config;
+});
+
 // Gastos Abertos
 export default new Vapi({
   axios: http,


### PR DESCRIPTION
Altera o tipo do content-type nas requisições relacionadas aos gastos aberto para o seu tipo correto removendo os erros que apareciam logo ao acessar o site